### PR TITLE
Add order timestamp to payment status response

### DIFF
--- a/Verifone/Core/Converter/Response/GetPaymentStatusResponseConverter.php
+++ b/Verifone/Core/Converter/Response/GetPaymentStatusResponseConverter.php
@@ -22,6 +22,7 @@ class GetPaymentStatusResponseConverter extends CoreResponseConverter
     const TRANSACTION_NUMBER = 'l-f-1-20_transaction-number';
     const PAYMENT_METHOD = 's-f-1-30_payment-method-code';
     const ORDER_NUMBER = 's-f-1-36_order-number';
+    const ORDER_TIMESTAMP = 't-f-14-19_order-timestamp';
 
     public function convert(TransportationResponse $response)
     {

--- a/Verifone/Core/DependencyInjection/CoreResponse/Interfaces/PaymentStatus.php
+++ b/Verifone/Core/DependencyInjection/CoreResponse/Interfaces/PaymentStatus.php
@@ -27,7 +27,8 @@ interface PaymentStatus
         $orderAmount,
         $transactionNumber,
         $paymentMethodCode,
-        $orderNumber
+        $orderNumber,
+        $orderTimestamp
     );
 
     public function getCode();
@@ -39,4 +40,6 @@ interface PaymentStatus
     public function getPaymentMethodCode();
 
     public function getOrderNumber();
+
+    public function getOrderTimestamp();
 }

--- a/Verifone/Core/DependencyInjection/CoreResponse/PaymentStatusImpl.php
+++ b/Verifone/Core/DependencyInjection/CoreResponse/PaymentStatusImpl.php
@@ -25,12 +25,15 @@ class PaymentStatusImpl implements PaymentStatus
 
     private $orderNumber;
 
+    private $orderTimestamp;
+
     public function __construct(
         $code,
         $orderAmount,
         $transactionNumber,
         $paymentMethodCode,
-        $orderNumber
+        $orderNumber,
+        $orderTimestamp
     )
     {
         $this->code = $code;
@@ -38,6 +41,7 @@ class PaymentStatusImpl implements PaymentStatus
         $this->transactionNumber = $transactionNumber;
         $this->paymentMethodCode = $paymentMethodCode;
         $this->orderNumber = $orderNumber;
+        $this->orderTimestamp = $orderTimestamp;
     }
 
     public function getCode()
@@ -77,5 +81,12 @@ class PaymentStatusImpl implements PaymentStatus
         return $this->orderNumber;
     }
 
+    /**
+     * @return mixed
+     */
+    public function getOrderTimestamp()
+    {
+        return $this->orderTimestamp;
+    }
 
 }


### PR DESCRIPTION
Having this helps to validate that the payment status returned is for the correct order. And anyhoo, since gateway returns this field let's allow using it.