### PR TITLE
Add fuction to add subscription code when getting saved payment methods

### DIFF
--- a/Verifone/Core/Service/Backend/GetSavedCreditCardsService.php
+++ b/Verifone/Core/Service/Backend/GetSavedCreditCardsService.php
@@ -60,6 +60,15 @@ final class GetSavedCreditCardsService extends AbstractBackendService
         }
     }
 
+    /**
+	 * @param string $code
+	 * Insert recurring payment subscription code to identify the customer
+	 */
+	public function insertRecurringPaymentSubscriptionCode($code)
+	{
+		$this->addToStorage(FieldConfigImpl::RECURRING_SUBSCRIPTION_CODE, $code);
+	}
+
     protected function getInterfaceVersion()
     {
         return self::INTERFACE_VERSION_VALUE;


### PR DESCRIPTION
To get saved methods for subscription, you'll need to send the subscription code in the request. This adds way of telling that for the request.