### PR TITLE
Allow setting recurring-payment => true without recurring subscription information

### DIFF
--- a/Verifone/Core/DependencyInjection/Service/PaymentInfoImpl.php
+++ b/Verifone/Core/DependencyInjection/Service/PaymentInfoImpl.php
@@ -40,7 +40,7 @@ class PaymentInfoImpl implements PaymentInfo
      * @param string $savedMethodId
      * @param string $note optional string, max 36 characters, will be cut if too long
      * @param bool $saveMaskedPan
-     * @param Recurring $recurring
+     * @param Recurring|boolean|null $recurring Recurring object to create new subscription, true to indicate recurring payment without subscription details, or null if not a recurring payment
      */
     public function __construct(
         $locale,
@@ -48,7 +48,7 @@ class PaymentInfoImpl implements PaymentInfo
         $savedMethodId = '',
         $note = '',
         $saveMaskedPan = false,
-        Recurring $recurring = null
+        $recurring = null
     ) {
         $this->locale = $locale;
         $this->saveMethod = $saveMethod;

--- a/Verifone/Core/Service/Backend/ProcessPaymentService.php
+++ b/Verifone/Core/Service/Backend/ProcessPaymentService.php
@@ -76,7 +76,9 @@ final class ProcessPaymentService extends AbstractBackendService
             $this->addToStorage(FieldConfigImpl::RECURRING_PAYMENT, self::RECURRING_PAYMENT_VALUE);
             $this->addToStorage(FieldConfigImpl::RECURRING_SUBSCRIPTION_NAME, $recurring->getSubscriptionName());
             $this->addToStorage(FieldConfigImpl::RECURRING_SUBSCRIPTION_CODE, $recurring->getSubscriptionCode());
-        }
+        } elseif( $recurring === true ) {
+			$this->addToStorage(FieldConfigImpl::RECURRING_PAYMENT, self::RECURRING_PAYMENT_VALUE);
+		}
 
         if ($paymentInfo->getSaveMaskedPan() === true) {
             $this->addToStorage(


### PR DESCRIPTION
This is needed when recurring payment renewal is processed. On renewal payment, gateway gives an error if also subscription name and code are sent.